### PR TITLE
fix:walk-backwards#1

### DIFF
--- a/js/entities/Keyboard.js
+++ b/js/entities/Keyboard.js
@@ -14,9 +14,26 @@ const Keyboard = {
       return;
     }
 
-    Keyboard.left = e.which === vkLeft;
-    Keyboard.right = e.which === vkRight;
-    Keyboard.up = e.which === vkUp;
-    Keyboard.down = e.which === vkDown;
+    let lastKey = Object.keys(Keyboard)
+      .slice(0, -1)
+      .filter((e) => Keyboard[e])[0];
+
+    const leftCondition = e.which === vkLeft && lastKey !== "right";
+    const rightCondition = e.which === vkRight && lastKey !== "left";
+    const upCondition = e.which === vkUp && lastKey !== "down";
+    const downCondition = e.which === vkDown && lastKey !== "up";
+
+    if (
+      ![leftCondition, rightCondition, upCondition, downCondition].filter(
+        (boolean) => boolean === true
+      ).length > 0
+    ) {
+      return;
+    }
+
+    Keyboard.left = leftCondition;
+    Keyboard.right = rightCondition;
+    Keyboard.up = upCondition;
+    Keyboard.down = downCondition;
   },
 };


### PR DESCRIPTION
fixes malfunction behavior of snake dying when use tries to walk backwards

about:
 this problem was solved with the following logic
 - get last key pressed
 - get the boolean values of the keyboard
 - check: if all the booleans are false the function stops keeping all the keyboard values

closes #1